### PR TITLE
feat: add SSR workbox support

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -23,6 +23,7 @@ export default defineNuxtConfig({
   },
   pwa: {
     registerType: 'autoUpdate',
+    enableSSR: true,
     manifest: {
       name: 'Nuxt Vite PWA',
       short_name: 'NuxtVitePWA',
@@ -48,6 +49,8 @@ export default defineNuxtConfig({
     },
     workbox: {
       navigateFallback: '/',
+      sourcemap: true,
+      mode: 'development',
       globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
     },
     client: {
@@ -57,7 +60,7 @@ export default defineNuxtConfig({
       periodicSyncForUpdates: 20,
     },
     devOptions: {
-      enabled: true,
+      enabled: false,
       suppressWarnings: true,
       navigateFallbackAllowlist: [/^\/$/],
       type: 'module',

--- a/playground/pages/about.vue
+++ b/playground/pages/about.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div>Nuxt Vite PWA</div>
+    <h1>Nuxt Vite PWA</h1>
     <NuxtLink to="/">
       Home 1
     </NuxtLink>

--- a/playground/pages/hi/[id].vue
+++ b/playground/pages/hi/[id].vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <h3 text-2xl font-500>
+      Hi,
+    </h3>
+    <div text-xl>
+      <NuxtPage :page-key="page => page.fullPath" />
+    </div>
+
+    <div>
+      <NuxtLink
+        class="m-3 text-sm btn"
+        to="/"
+      >
+        Back
+      </NuxtLink>
+    </div>
+  </div>
+</template>

--- a/playground/pages/hi/[id]/detail.vue
+++ b/playground/pages/hi/[id]/detail.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const route = useRoute<'hi-id-detail'>()
+const name = route.params.id ?? ''
+if (process.server) {
+  // eslint-disable-next-line no-console
+  console.log('Server side', name)
+}
+</script>
+
+<template>
+  <div>
+    <div text-xl>
+      Detail {{ name }}
+    </div>
+    <NuxtLink :to="`/hi/${name}`" class="m-3 text-sm btn">
+      Back Hi
+    </NuxtLink>
+  </div>
+</template>

--- a/playground/pages/hi/[id]/index.vue
+++ b/playground/pages/hi/[id]/index.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const route = useRoute<'hi-id'>()
+const name = route.params.id ?? ''
+if (process.server) {
+  // eslint-disable-next-line no-console
+  console.log('Server side', name)
+}
+</script>
+
+<template>
+  <div>
+    <div text-xl>
+      {{ name }}!
+    </div>
+    <NuxtLink :to="`/hi/${name}/detail`" class="m-3 text-sm btn">
+      Detail
+    </NuxtLink>
+  </div>
+</template>

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,6 +1,38 @@
+<script setup lang="ts">
+const name = ref('')
+
+const router = useRouter()
+function go() {
+  if (name.value)
+    router.push(`/hi/${encodeURIComponent(name.value)}`)
+}
+</script>
+
 <template>
   <div>
     <div>Nuxt Vite PWA</div>
+    <div>
+      <input
+        id="input"
+        v-model="name"
+        placeholder="What's your name?"
+        type="text"
+        autocomplete="off"
+        @keydown.enter="go"
+      >
+      <div>
+        <button
+          :disabled="!name"
+          @click="go"
+        >
+          GO
+        </button>
+      </div>
+    </div>
+    <NuxtLink to="/list">
+      Go to list
+    </NuxtLink>
+    <br>
     <NuxtLink to="/about">
       About
     </NuxtLink>

--- a/playground/pages/list.vue
+++ b/playground/pages/list.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <h1>List</h1>
+    <NuxtPage />
+    <NuxtLink to="/">
+      Go to index
+    </nuxtlink>
+  </div>
+</template>

--- a/playground/pages/list/[id]/index.vue
+++ b/playground/pages/list/[id]/index.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+definePageMeta({
+  key: route => route.fullPath,
+})
+const route = useRoute<'list-id'>()
+const name = route.params.id ?? ''
+if (process.server) {
+  // eslint-disable-next-line no-console
+  console.log('Server side', name)
+}
+</script>
+
+<template>
+  <div>
+    <h1>Child</h1>
+    <NuxtLink to="/list">
+      Back
+    </NuxtLink>
+  </div>
+</template>

--- a/playground/pages/list/example.vue
+++ b/playground/pages/list/example.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <NuxtPage />
+    <NuxtLink to="/list">
+      Back
+    </NuxtLink>
+  </div>
+</template>

--- a/playground/pages/list/example/index.vue
+++ b/playground/pages/list/example/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Example</h1>
+  </div>
+</template>

--- a/playground/pages/list/example2.vue
+++ b/playground/pages/list/example2.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <h1>Example 2</h1>
+    <NuxtLink to="/list">
+      Back
+    </NuxtLink>
+  </div>
+</template>

--- a/playground/pages/list/index.vue
+++ b/playground/pages/list/index.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <div>
+    <NuxtLink to="/list/1">
+      Go to /list/1
+    </NuxtLink>
+    <br>
+    <NuxtLink to="/list/2">
+      Go to /list/2
+    </NuxtLink>
+    <br>
+    <NuxtLink to="/list/example">
+      Go to example
+    </NuxtLink>
+    <br>
+    <NuxtLink to="/list/example2">
+      Go to example 2
+    </NuxtLink>
+  </div>
+</template>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,15 @@
-import type { Nuxt } from '@nuxt/schema'
+import type { Nuxt, NuxtPage } from '@nuxt/schema'
 import { resolve } from 'pathe'
 import type { NitroConfig } from 'nitropack'
+import type { RuntimeCaching } from 'workbox-build'
 import type { ModuleOptions } from './types'
 
-export function configurePWAOptions(options: ModuleOptions, nuxt: Nuxt, nitroConfig: NitroConfig) {
+export function configurePWAOptions(
+  options: ModuleOptions,
+  nuxt: Nuxt,
+  nitroConfig: NitroConfig,
+  ssrPages?: NuxtPage[],
+) {
   if (!options.outDir) {
     const publicDir = nitroConfig.output?.publicDir ?? nuxt.options.nitro?.output?.publicDir
     options.outDir = publicDir ? resolve(publicDir) : resolve(nuxt.options.buildDir, '../.output/public')
@@ -20,6 +26,7 @@ export function configurePWAOptions(options: ModuleOptions, nuxt: Nuxt, nitroCon
   >
 
   if (options.strategies === 'injectManifest') {
+    // TODO: handle enableSSR, we need to inject the routeRules with a custom recipe
     options.injectManifest = options.injectManifest ?? {}
     config = options.injectManifest
   }
@@ -34,6 +41,34 @@ export function configurePWAOptions(options: ModuleOptions, nuxt: Nuxt, nitroCon
       options.workbox.navigateFallback = options.workbox.navigateFallback ?? nuxt.options.app.baseURL ?? '/'
       if (options.devOptions?.enabled && !options.devOptions.navigateFallbackAllowlist)
         options.devOptions.navigateFallbackAllowlist = [nuxt.options.app.baseURL ? new RegExp(nuxt.options.app.baseURL) : /\//]
+    }
+    else if (ssrPages?.length) {
+      // 1. filter prerender pages: will go to the sw precache manifest
+      // what happens if prerender is enabled but prerender routes with ssr?
+      // don't use nitroConfig, we have _nuxt and __nuxt_error
+      const prerenderPages = nuxt.options.nitro.prerender?.routes ?? []
+      const rules = collectRules(ssrPages.filter(p => !prerenderPages.includes(p.path)))
+      // 2. include routeRules: don't use nitroConfig, we have _nuxt and __nuxt_error
+      Object.entries(nuxt.options.nitro.routeRules ?? {}).filter(([, rule]) => {
+        return !rule.prerender && rule.ssr
+      }).forEach(([path]) => rules.add(createRouteRuleRegex(path)))
+      // 2. prepare runtime caching for ssr pages
+      const routesInfo = Array.from(rules).map(createSSRHandler)
+      // 3. configure workbox properly: since we have 2 builds we need to check if previously added
+      if (routesInfo.length > 0) {
+        const navigateFallbackDenylist = options.workbox.navigateFallbackDenylist ?? []
+        const runtimeCaching = options.workbox.runtimeCaching ?? []
+        routesInfo.forEach((r) => {
+          const regexp = r.urlPattern as RegExp
+          if (!navigateFallbackDenylist.some(d => d.source === regexp.source))
+            navigateFallbackDenylist.push(regexp)
+
+          if (!runtimeCaching.some(d => typeof d.urlPattern !== 'string' && typeof d.urlPattern !== 'function' && d.urlPattern.source === regexp.source))
+            runtimeCaching.push(r)
+        })
+        options.workbox.navigateFallbackDenylist = navigateFallbackDenylist
+        options.workbox.runtimeCaching = runtimeCaching
+      }
     }
     config = options.workbox
   }
@@ -58,4 +93,47 @@ function createManifestTransform(base: string): import('workbox-build').Manifest
 
     return { manifest: entries, warnings: [] }
   }
+}
+
+function createSSRHandler(route: string): RuntimeCaching {
+  return {
+    urlPattern: new RegExp(route),
+    handler: 'NetworkOnly',
+  }
+}
+
+function createRouteRegex(path: string): [route: string, dynamic: boolean] {
+  const dynamicRoute = path.indexOf(':')
+  return dynamicRoute > -1 ? [`^${path.slice(0, dynamicRoute)}`, true] : [`^${path}$`, false]
+}
+
+function createRouteRuleRegex(routeRule: string) {
+  const routePath = routeRule.endsWith('/*')
+    ? `^${routeRule.slice(routeRule.length - 1)}`
+    : routeRule.endsWith('/**')
+      ? `^${routeRule.slice(routeRule.length - 2)}`
+      : `^${routeRule}$`
+
+  return `${routePath.replace(/\*\*?/g, '.*')}`
+}
+
+function traversePage(page: NuxtPage, rules: Set<string>) {
+  // If a page is excluded, then all its children should.
+  // We'll have static and dynamic pages, for example:
+  // hi/[id].vue: this case is not a problem, we can exclude the page with params
+  // /list with server content: a table for example, in this case we need to exclude the page and the children
+  // In previous case, if we have /list/[id].vue, we exclude all children
+  const [route, dynamic] = createRouteRegex(page.path)
+  // In case we have children, exclude all of them if the route is not dynamic.
+  // We replace the $ with / to match any child route
+  if (page.children?.length && !dynamic)
+    rules.add(`${route.slice(0, route.length - 1)}/`)
+
+  rules.add(route)
+}
+
+function collectRules(ssrPages: NuxtPage[]) {
+  const rules = new Set<string>()
+  ssrPages.forEach(p => traversePage(p, rules))
+  return rules
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,17 @@ export interface ClientOptions {
 }
 
 export interface ModuleOptions extends Partial<VitePWAOptions> {
+  /**
+   * If SSR is enabled and this option is enabled, the plugin will inject a custom runtime caching to allow
+   * SSR pages to work with NetworkOnly strategy.
+   *
+   * This option is only available when using `generateSW` strategy.
+   *
+   * Beware, your application should handle offline.
+   *
+   * @default false
+   */
+  enableSSR?: boolean
   registerWebManifestInRouteRules?: boolean
   /**
    * Writes the plugin to disk: defaults to false (debug).


### PR DESCRIPTION
This PR includes support for SSR Pages via custom runtime caching plugins using NetworkOnly handler:
- any SSR page path will be included in the sw precache `denylist` entry with exact match_ if includes dynamic route the plugin will include a wildcard regex instead
- any SSR page path will include a custom handler
- if any not dynamic SSR page include ahs children, then a wilcard will be also included for all the children in the denylist and in the runtime caching entries