### PR TITLE
fix(types): module augmentation for nuxt and vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/nuxt",
   "type": "module",
   "version": "0.1.1",
-  "packageManager": "pnpm@8.9.2",
+  "packageManager": "pnpm@8.10.2",
   "description": "Zero-config PWA for Nuxt 3",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",
@@ -34,7 +34,7 @@
     "templates"
   ],
   "scripts": {
-    "prepack": "nuxt-module-build",
+    "prepack": "nuxt-module-build prepare && nuxt-module-build",
     "dev": "nuxi dev playground",
     "dev:generate": "nuxi generate playground",
     "dev:generate:netlify": "NITRO_PRESET=netlify nuxi generate playground",
@@ -43,7 +43,6 @@
     "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
     "dev:preview:build": "nr dev:build && node playground/.output/server/index.mjs",
     "dev:preview:generate": "nr dev:generate && serve playground/dist",
-    "prepublishOnly": "npm run prepack",
     "release": "bumpp && npm publish",
     "lint": "eslint .",
     "lint-fix": "nr lint --fix",

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,9 @@ export function configurePWAOptions(options: ModuleOptions, nuxt: Nuxt, nitroCon
       if (options.devOptions?.enabled && !options.devOptions.navigateFallbackAllowlist)
         options.devOptions.navigateFallbackAllowlist = [nuxt.options.app.baseURL ? new RegExp(nuxt.options.app.baseURL) : /\//]
     }
+    if (!options.workbox.navigateFallback)
+      options.workbox.navigateFallback = nuxt.options.app.baseURL ?? '/'
+
     config = options.workbox
   }
   if (!nuxt.options.dev)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,9 +15,14 @@ export interface PwaInjection {
   getSWRegistration: () => ServiceWorkerRegistration | undefined
 }
 
-// TODO: fix this issue upstream in nuxt/module-builder
-declare module '#app' {
+declare module '#app/nuxt' {
   interface NuxtApp {
+    $pwa: UnwrapNestedRefs<PwaInjection>
+  }
+}
+
+declare module '@vue/runtime-core' {
+  export interface ComponentCustomProperties {
     $pwa: UnwrapNestedRefs<PwaInjection>
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
This PR also includes configuring `workbox.navigateFallback=<base>` when missing.

VSCode:
![imagen](https://github.com/vite-pwa/nuxt/assets/6311119/2a3d79aa-f3d7-4405-b039-65ae7166ddc8)

IntelliJ UE:
![imagen](https://github.com/vite-pwa/nuxt/assets/6311119/d7eaddb9-3e5f-40e2-9de3-b724f1331f5c)



closes #84 