### PR TITLE
feat: allow configure falsy navigate fallback and custom manifest transforms

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -49,7 +49,6 @@ export default defineNuxtConfig({
       ],
     },
     workbox: {
-      navigateFallback: '/',
       globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
     },
     client: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,12 +35,14 @@ export function configurePWAOptions(options: ModuleOptions, nuxt: Nuxt, nitroCon
       if (options.devOptions?.enabled && !options.devOptions.navigateFallbackAllowlist)
         options.devOptions.navigateFallbackAllowlist = [nuxt.options.app.baseURL ? new RegExp(nuxt.options.app.baseURL) : /\//]
     }
-    if (!options.workbox.navigateFallback)
+    // the user may want to disable offline support
+    if (!('navigateFallback' in options.workbox))
       options.workbox.navigateFallback = nuxt.options.app.baseURL ?? '/'
 
     config = options.workbox
   }
-  if (!nuxt.options.dev)
+  // allow override manifestTransforms
+  if (!nuxt.options.dev && !config.manifestTransforms)
     config.manifestTransforms = [createManifestTransform(nuxt.options.app.baseURL ?? '/')]
 }
 


### PR DESCRIPTION
Current version:
- when using `generate` strategy and providing `navigateFallback` with `null` or `undefined`, the module will change the value to the base
- when provinding custom `manifestTransforms`, the module will change the value with its internal impl.