### PR TITLE
fix: `@nuxt/schema` module augmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/nuxt",
   "type": "module",
   "version": "0.3.1",
-  "packageManager": "pnpm@8.10.5",
+  "packageManager": "pnpm@8.11.0",
   "description": "Zero-config PWA for Nuxt 3",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,7 @@
     "generate": "nuxi generate"
   },
   "devDependencies": {
+    "@vite-pwa/nuxt": "workspace:*",
     "nuxt": "^3.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
 
   playground:
     devDependencies:
+      '@vite-pwa/nuxt':
+        specifier: workspace:*
+        version: link:..
       nuxt:
         specifier: ^3.8.2
         version: 3.8.2(@types/node@18.11.18)(eslint@8.54.0)(rollup@3.29.4)(typescript@5.3.2)(vite@4.5.0)(vue-tsc@1.8.22)

--- a/src/module.ts
+++ b/src/module.ts
@@ -274,9 +274,9 @@ export interface ModuleOptions extends PwaModuleOptions {}
 
 declare module '@nuxt/schema' {
   interface NuxtConfig {
-    ['vuetify']?: Partial<ModuleOptions>
+    ['pwa']?: Partial<ModuleOptions>
   }
   interface NuxtOptions {
-    ['vuetify']?: ModuleOptions
+    ['pwa']?: ModuleOptions
   }
 }


### PR DESCRIPTION
This PR also includes `@vite-pwa/nuxt` as dev dependency in playground  using workspace protocol!.

closes #98