### PR TITLE
feat: support Vite 5

### DIFF
--- a/client-test/sw.spec.ts
+++ b/client-test/sw.spec.ts
@@ -39,6 +39,7 @@ test('The service worker is registered and cache storage is present', async ({ p
   expect(urls.some(url => url.startsWith('manifest.webmanifest?__WB_REVISION__='))).toEqual(true)
   expect(urls.some(url => url.startsWith('?__WB_REVISION__='))).toEqual(true)
   expect(urls.some(url => url.startsWith('about?__WB_REVISION__='))).toEqual(true)
+  // dontCacheBustURLsMatching: any asset in _nuxt folder shouldn't have a revision (?__WB_REVISION__=)
   expect(urls.some(url => url.startsWith('_nuxt/') && url.endsWith('.css'))).toEqual(true)
   expect(urls.some(url => url.startsWith('_nuxt/') && url.endsWith('.js'))).toEqual(true)
   expect(urls.some(url => url.includes('_payload.json?__WB_REVISION__='))).toEqual(true)

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,33 +46,31 @@ export function configurePWAOptions(
 
     config = options.workbox
   }
-  // Vite 5 support
-  let dontCacheBustURLsMatching = nuxt.options.app.buildAssetsDir ?? '_nuxt/'
-  if (dontCacheBustURLsMatching[0] === '/')
-    dontCacheBustURLsMatching = dontCacheBustURLsMatching.slice(1)
-  if (dontCacheBustURLsMatching[dontCacheBustURLsMatching.length - 1] !== '/')
-    dontCacheBustURLsMatching += '/'
-  config.dontCacheBustURLsMatching = new RegExp(dontCacheBustURLsMatching)
+
+  let buildAssetsDir = nuxt.options.app.buildAssetsDir ?? '_nuxt/'
+  if (buildAssetsDir[0] === '/')
+    buildAssetsDir = buildAssetsDir.slice(1)
+  if (buildAssetsDir[buildAssetsDir.length - 1] !== '/')
+    buildAssetsDir += '/'
+
+  // Vite 5 support: allow override dontCacheBustURLsMatching
+  if (!('dontCacheBustURLsMatching' in config))
+    config.dontCacheBustURLsMatching = new RegExp(buildAssetsDir)
+
   // handle payload extraction
   if (nuxt.options.experimental.payloadExtraction) {
     config.globPatterns = config.globPatterns ?? []
     config.globPatterns.push('**/_payload.json')
   }
+
+  // handle Nuxt App Manifest
   let appManifestFolder: string | undefined
-  // check for Nuxt App Manifest
   if (nuxt3_8 && nuxt.options.experimental.appManifest) {
     config.globPatterns = config.globPatterns ?? []
-    appManifestFolder = nuxt.options.app.buildAssetsDir ?? '_nuxt/'
-    if (appManifestFolder[0] === '/')
-      appManifestFolder = appManifestFolder.slice(1)
-
-    if (appManifestFolder[appManifestFolder.length - 1] !== '/')
-      appManifestFolder += '/'
-
-    appManifestFolder += 'builds/'
-
+    appManifestFolder = `${buildAssetsDir}builds/`
     config.globPatterns.push(`${appManifestFolder}**/*.json`)
   }
+
   // allow override manifestTransforms
   if (!nuxt.options.dev && !config.manifestTransforms)
     config.manifestTransforms = [createManifestTransform(nuxt.options.app.baseURL ?? '/', appManifestFolder)]

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,13 @@ export function configurePWAOptions(
 
     config = options.workbox
   }
+  // Vite 5 support
+  let dontCacheBustURLsMatching = nuxt.options.app.buildAssetsDir ?? '_nuxt/'
+  if (dontCacheBustURLsMatching[0] === '/')
+    dontCacheBustURLsMatching = dontCacheBustURLsMatching.slice(1)
+  if (dontCacheBustURLsMatching[dontCacheBustURLsMatching.length - 1] !== '/')
+    dontCacheBustURLsMatching += '/'
+  config.dontCacheBustURLsMatching = new RegExp(dontCacheBustURLsMatching)
   // handle payload extraction
   if (nuxt.options.experimental.payloadExtraction) {
     config.globPatterns = config.globPatterns ?? []


### PR DESCRIPTION
Don't merge yet, only for Nuxt ecosystem-ci, we should also update `vite-plugin-pwa` and probably Nuxt.

/cc @danielroe if you want to use `userquin/nuxt-ecosystem-ci-vite-5` branch in the meantime.

Don't remove branch until Daniel changes it in the ecosystem-ci.