### PR TITLE
fix: add revision to `builds/latest.json` precache manifest entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/nuxt",
   "type": "module",
   "version": "0.3.5",
-  "packageManager": "pnpm@8.11.0",
+  "packageManager": "pnpm@8.12.1",
   "description": "Zero-config PWA for Nuxt 3",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import { lstat } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
 import type { Nuxt } from '@nuxt/schema'
 import { resolve } from 'pathe'
 import type { NitroConfig } from 'nitropack'
@@ -80,10 +83,14 @@ export function configurePWAOptions(
 
   // allow override manifestTransforms
   if (!nuxt.options.dev && !config.manifestTransforms)
-    config.manifestTransforms = [createManifestTransform(nuxt.options.app.baseURL ?? '/', appManifestFolder)]
+    config.manifestTransforms = [createManifestTransform(nuxt.options.app.baseURL ?? '/', options.outDir, appManifestFolder)]
 }
 
-function createManifestTransform(base: string, appManifestFolder?: string): import('workbox-build').ManifestTransform {
+function createManifestTransform(
+  base: string,
+  publicFolder: string,
+  appManifestFolder?: string,
+): import('workbox-build').ManifestTransform {
   return async (entries) => {
     entries.filter(e => e && e.url.endsWith('.html')).forEach((e) => {
       const url = e.url.startsWith('/') ? e.url.slice(1) : e.url
@@ -104,6 +111,32 @@ function createManifestTransform(base: string, appManifestFolder?: string): impo
       entries.filter(e => e && e.url.startsWith(appManifestFolder) && regExp.test(e.url)).forEach((e) => {
         e.revision = null
       })
+      // add revision to latest.json file: we are excluding `_nuxt/` assets from dontCacheBustURLsMatching
+      const latest = `${appManifestFolder}latest.json`
+      const latestJson = resolve(publicFolder, latest)
+      const data = await lstat(latestJson).catch(() => undefined)
+      if (data?.isFile()) {
+        const revision = await new Promise<string>((resolve, reject) => {
+          const cHash = createHash('MD5')
+          const stream = createReadStream(latestJson)
+          stream.on('error', (err) => {
+            reject(err)
+          })
+          stream.on('data', chunk => cHash.update(chunk))
+          stream.on('end', () => {
+            resolve(`${cHash.digest('hex')}`)
+          })
+        })
+
+        const latestEntry = entries.find(e => e && e.url === latest)
+        if (latestEntry)
+          latestEntry.revision = revision
+        else
+          entries.push({ url: latest, revision, size: data.size })
+      }
+      else {
+        entries = entries.filter(e => e.url !== latest)
+      }
     }
 
     return { manifest: entries, warnings: [] }

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,7 +92,7 @@ function createManifestTransform(
   appManifestFolder?: string,
 ): import('workbox-build').ManifestTransform {
   return async (entries) => {
-    entries.filter(e => e && e.url.endsWith('.html')).forEach((e) => {
+    entries.filter(e => e.url.endsWith('.html')).forEach((e) => {
       const url = e.url.startsWith('/') ? e.url.slice(1) : e.url
       if (url === 'index.html') {
         e.url = base
@@ -108,7 +108,7 @@ function createManifestTransform(
       const regExp = /(\/)?[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}\.json$/i
       // we need to remove the revision from the sw prechaing manifest, UUID is enough:
       // we don't use dontCacheBustURLsMatching, single regex
-      entries.filter(e => e && e.url.startsWith(appManifestFolder) && regExp.test(e.url)).forEach((e) => {
+      entries.filter(e => e.url.startsWith(appManifestFolder) && regExp.test(e.url)).forEach((e) => {
         e.revision = null
       })
       // add revision to latest.json file: we are excluding `_nuxt/` assets from dontCacheBustURLsMatching
@@ -128,7 +128,7 @@ function createManifestTransform(
           })
         })
 
-        const latestEntry = entries.find(e => e && e.url === latest)
+        const latestEntry = entries.find(e => e.url === latest)
         if (latestEntry)
           latestEntry.revision = revision
         else

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,7 @@ function createManifestTransform(
     })
 
     if (appManifestFolder) {
+      // this shouldn't be necessary, since we are using dontCacheBustURLsMatching
       const regExp = /(\/)?[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}\.json$/i
       // we need to remove the revision from the sw prechaing manifest, UUID is enough:
       // we don't use dontCacheBustURLsMatching, single regex
@@ -124,7 +125,7 @@ function createManifestTransform(
           })
           stream.on('data', chunk => cHash.update(chunk))
           stream.on('end', () => {
-            resolve(`${cHash.digest('hex')}`)
+            resolve(cHash.digest('hex'))
           })
         })
 


### PR DESCRIPTION
Since we include `_nuxt/`  folder in `dontCacheBustURLsMatching`, we need to add the `hash/revision`, it is `null`