### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,7 @@ Zero-config PWA Plugin for Nuxt 3
 > For older versions, `@vite-pwa/nuxt` requires Vite 3.2.0+ and Nuxt 3.0.0+.
 
 ```bash
-npm i @vite-pwa/nuxt -D 
-
-# yarn 
-yarn add @vite-pwa/nuxt -D
-
-# pnpm 
-pnpm add @vite-pwa/nuxt -D
+npx nuxi@latest module add vite-pwa-nuxt
 ```
 
 ## 🦄 Usage

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Zero-config PWA Plugin for Nuxt 3
 > For older versions, `@vite-pwa/nuxt` requires Vite 3.2.0+ and Nuxt 3.0.0+.
 
 ```bash
-npx nuxi@latest module add vite-pwa-nuxt
+npx nuxi@latest module add @vite-pwa/nuxt
 ```
 
 ## 🦄 Usage


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
