### PR TITLE
fix: pass the results of userChoice to the developers

### DIFF
--- a/src/runtime/plugins/pwa.client.ts
+++ b/src/runtime/plugins/pwa.client.ts
@@ -122,7 +122,7 @@ const plugin: Plugin<{
       showInstallPrompt.value = false
       await nextTick()
       deferredPrompt.prompt()
-      await deferredPrompt.userChoice
+      return await deferredPrompt.userChoice
     }
   }
 

--- a/src/runtime/plugins/pwa.client.ts
+++ b/src/runtime/plugins/pwa.client.ts
@@ -2,7 +2,7 @@ import { nextTick, reactive, ref } from 'vue'
 import type { UnwrapNestedRefs } from 'vue'
 import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { display, installPrompt, periodicSyncForUpdates } from 'virtual:nuxt-pwa-configuration'
-import type {BeforeInstallPromptEvent, PwaInjection, UserChoice} from './types'
+import type { BeforeInstallPromptEvent, PwaInjection, UserChoice } from './types'
 import { defineNuxtPlugin } from '#imports'
 import type { Plugin } from '#app'
 

--- a/src/runtime/plugins/pwa.client.ts
+++ b/src/runtime/plugins/pwa.client.ts
@@ -2,7 +2,7 @@ import { nextTick, reactive, ref } from 'vue'
 import type { UnwrapNestedRefs } from 'vue'
 import { useRegisterSW } from 'virtual:pwa-register/vue'
 import { display, installPrompt, periodicSyncForUpdates } from 'virtual:nuxt-pwa-configuration'
-import type { PwaInjection } from './types'
+import type {BeforeInstallPromptEvent, PwaInjection, UserChoice} from './types'
 import { defineNuxtPlugin } from '#imports'
 import type { Plugin } from '#app'
 
@@ -83,20 +83,15 @@ const plugin: Plugin<{
     needRefresh.value = false
   }
 
-  let install: () => Promise<void> = () => Promise.resolve()
+  let install: () => Promise<UserChoice | undefined> = () => Promise.resolve(undefined)
   let cancelInstall: () => void = () => {}
 
   if (!hideInstall.value) {
-    type InstallPromptEvent = Event & {
-      prompt: () => void
-      userChoice: Promise<{ outcome: 'dismissed' | 'accepted' }>
-    }
-
-    let deferredPrompt: InstallPromptEvent | undefined
+    let deferredPrompt: BeforeInstallPromptEvent | undefined
 
     const beforeInstallPrompt = (e: Event) => {
       e.preventDefault()
-      deferredPrompt = e as InstallPromptEvent
+      deferredPrompt = e as BeforeInstallPromptEvent
       showInstallPrompt.value = true
     }
     window.addEventListener('beforeinstallprompt', beforeInstallPrompt)
@@ -116,7 +111,7 @@ const plugin: Plugin<{
     install = async () => {
       if (!showInstallPrompt.value || !deferredPrompt) {
         showInstallPrompt.value = false
-        return
+        return undefined
       }
 
       showInstallPrompt.value = false

--- a/src/runtime/plugins/types.d.ts
+++ b/src/runtime/plugins/types.d.ts
@@ -1,6 +1,13 @@
 import type { Ref } from 'vue'
 import type { UnwrapNestedRefs } from 'vue'
 
+export type UserChoiceType = 'accepted' | 'dismissed'
+
+export type UserChoice = {
+  outcome: UserChoiceType
+  platform: string
+}
+
 export interface PwaInjection {
   /**
    * @deprecated use `isPWAInstalled` instead
@@ -9,7 +16,7 @@ export interface PwaInjection {
   isPWAInstalled: Ref<boolean>
   showInstallPrompt: Ref<boolean>
   cancelInstall: () => void
-  install: () => Promise<void>
+  install: () => Promise<UserChoice>
   swActivated: Ref<boolean>
   registrationError: Ref<boolean>
   offlineReady: Ref<boolean>

--- a/src/runtime/plugins/types.d.ts
+++ b/src/runtime/plugins/types.d.ts
@@ -1,11 +1,14 @@
 import type { Ref } from 'vue'
 import type { UnwrapNestedRefs } from 'vue'
 
-export type UserChoiceType = 'accepted' | 'dismissed'
-
-export type UserChoice = {
-  outcome: UserChoiceType
+export interface UserChoice {
+  outcome: 'accepted' | 'dismissed'
   platform: string
+}
+
+export type BeforeInstallPromptEvent = Event & {
+  prompt: () => void
+  userChoice: Promise<UserChoice>
 }
 
 export interface PwaInjection {
@@ -16,7 +19,7 @@ export interface PwaInjection {
   isPWAInstalled: Ref<boolean>
   showInstallPrompt: Ref<boolean>
   cancelInstall: () => void
-  install: () => Promise<UserChoice>
+  install: () => Promise<UserChoice | undefined>
   swActivated: Ref<boolean>
   registrationError: Ref<boolean>
   offlineReady: Ref<boolean>


### PR DESCRIPTION
There are times when we need to handle different logic based on the result of userChoice.

````js
$pwa?.install().then((userChoice) => {
	if (userChoice.outcome === 'accepted') {
		console.log('accepted install');
	}
})
````