### PR TITLE
fix!: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/src/runtime/plugins/types.d.ts
+++ b/src/runtime/plugins/types.d.ts
@@ -35,7 +35,7 @@ declare module '#app' {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $pwa?: UnwrapNestedRefs<PwaInjection>
   }

--- a/src/utils/pwa-icons-helper.ts
+++ b/src/utils/pwa-icons-helper.ts
@@ -64,7 +64,7 @@ declare module '#app' {
   }
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $pwaIcons?: PWAIcons
   }


### PR DESCRIPTION
In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment vue rather than @vue/runtime core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it must be done by all libraries or it will break types for other libraries.