### PR TITLE
chore: fix Nuxt ecosystem ci scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
     "lint-fix": "nr lint --fix",
     "test:build:serve": "PORT=4173 node playground/.output/server/index.mjs",
     "test:generate:serve": "PORT=4173 serve playground/dist",
-    "test:build": "nr dev:build && TEST_BUILD=true vitest run && TEST_BUILD=true playwright test",
-    "test:generate": "nr dev:generate && vitest run && playwright test",
-    "test:local": "nr test:build && nr test:generate",
-    "test": "NUXT_ECOSYSTEM_CI=true nr test:build && nr test:generate",
+    "test:build": "nr dev:build && NUXT_ECOSYSTEM_CI=true TEST_BUILD=true vitest run && TEST_BUILD=true playwright test",
+    "test:generate": "nr dev:generate && NUXT_ECOSYSTEM_CI=true vitest run && playwright test",
+    "test:build:local": "nr dev:build && TEST_BUILD=true vitest run && TEST_BUILD=true playwright test",
+    "test:generate:local": "nr dev:generate && vitest run && playwright test",
+    "test:local": "nr test:build:local && nr test:generate:local",
+    "test": "nr test:build && nr test:generate",
     "test:with-build": "nr dev:prepare && nr prepack && nr test"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR splits the tests scripts: we need `NUXT_ECOSYSTEM_CI=true` on Vitest not in Playwright tests 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
