### PR TITLE
fix: remove `@nuxt/schema` module augmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/nuxt",
   "type": "module",
   "version": "0.10.1",
-  "packageManager": "pnpm@9.8.0",
+  "packageManager": "pnpm@9.9.0",
   "description": "Zero-config PWA for Nuxt 3",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,9 @@ import { doSetup } from './utils/module'
 
 export * from './types'
 
-export default defineNuxtModule<PwaModuleOptions>({
+export interface ModuleOptions extends PwaModuleOptions {}
+
+export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'pwa',
     configKey: 'pwa',
@@ -34,14 +36,3 @@ export default defineNuxtModule<PwaModuleOptions>({
     await doSetup(options, nuxt)
   },
 })
-
-export interface ModuleOptions extends PwaModuleOptions {}
-
-declare module '@nuxt/schema' {
-  interface NuxtConfig {
-    ['pwa']?: Partial<ModuleOptions>
-  }
-  interface NuxtOptions {
-    ['pwa']?: ModuleOptions
-  }
-}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR includes:
- fix Nuxt ecosystem-ci removing `@nuxt/schema` module augmentation
- bump pnpm to 9.9.0

/cc @danielroe 

Daniel, I also have `#app` module augmentation in Vuetify, I guess I also neeed to remove it, right?

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
