### PR TITLE
fix: remove missing sourcemap vue-router warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dev:preview:generate": "nr dev:generate && serve playground/dist",
     "release": "bumpp && npm publish",
     "lint": "eslint .",
-    "lint-fix": "nr lint --fix",
+    "lint:fix": "nr lint --fix",
     "test:build:serve": "PORT=4173 node playground/.output/server/index.mjs",
     "test:generate:serve": "PORT=4173 serve playground/dist",
     "test:build": "nr dev:build && NUXT_ECOSYSTEM_CI=true TEST_BUILD=true vitest run && TEST_BUILD=true playwright test",
@@ -59,6 +59,14 @@
     "test:local": "nr test:build:local && nr test:generate:local",
     "test": "nr test:build && nr test:generate",
     "test:with-build": "nr dev:prepare && nr prepack && nr test"
+  },
+  "peerDependencies": {
+    "@vite-pwa/assets-generator": "^0.2.6"
+  },
+  "peerDependenciesMeta": {
+    "@vite-pwa/assets-generator": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@nuxt/kit": "^3.9.0",
@@ -88,20 +96,13 @@
   "resolutions": {
     "@nuxt/kit": "^3.10.1"
   },
-  "peerDependencies": {
-    "@vite-pwa/assets-generator": "^0.2.6"
-  },
-  "peerDependenciesMeta": {
-    "@vite-pwa/assets-generator": {
-      "optional": true
-    }
-  },
   "build": {
     "externals": [
       "node:child_process",
       "node:fs",
       "consola",
       "esbuild",
+      "h3",
       "pathe",
       "rollup",
       "ufo",

--- a/playground-assets/nuxt.config.ts
+++ b/playground-assets/nuxt.config.ts
@@ -1,7 +1,3 @@
-import process from 'node:process'
-
-const sw = process.env.SW === 'true'
-
 export default defineNuxtConfig({
   /* ssr: false, */
   // typescript,

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path'
+import fs from 'node:fs'
+import { eventHandler } from 'h3'
+
+export function dev(
+  swMap: string,
+  resolvedSwMapFile: string,
+  worboxMap: string,
+  buildDir: string,
+  baseURL: string,
+) {
+  return eventHandler(async (event) => {
+    const url = event.path
+    if (!url)
+      return
+
+    const file = url === swMap
+      ? resolvedSwMapFile
+      : url.startsWith(worboxMap) && url.endsWith('.js.map')
+        ? join(
+          buildDir,
+          'dev-sw-dist',
+          url.slice(baseURL.length),
+        )
+        : undefined
+
+    if (file) {
+      try {
+        await waitFor(() => fs.existsSync(file))
+        const map = fs.readFileSync(file, 'utf-8')
+        event.headers.set('Content-Type', 'application/json')
+        event.headers.set('Cache-Control', 'public, max-age=0, must-revalidate')
+        event.headers.set('Content-Length', `${map.length}`)
+        event.node.res.end(map)
+      }
+      catch {
+      }
+    }
+  })
+}
+
+async function waitFor(method: () => boolean, retries = 5): Promise<void> {
+  if (method())
+    return
+
+  if (retries === 0)
+    throw new Error('Timeout in waitFor')
+
+  await new Promise(resolve => setTimeout(resolve, 300))
+
+  return waitFor(method, retries - 1)
+}


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
We need to skip Nitro when using `generateSW` strategy with `sourcemap` enabled:

![imagen](https://github.com/user-attachments/assets/4ac316dd-1880-473a-b235-95fb2ca148f1)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
