### PR TITLE
fix: add missing `usePWA` composable

### DIFF
--- a/playground/pages/about.vue
+++ b/playground/pages/about.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+const pwa = usePWA()
 </script>
 
 <template>
   <div>
     <h1>Nuxt Vite PWA</h1>
     <ClientOnly>
-      PWA Installed: {{ $pwa?.isPWAInstalled }}
+      PWA Installed: {{ pwa?.isPWAInstalled }}
     </ClientOnly>
     <NuxtLink to="/">
       Home 1

--- a/src/utils/pwa-icons-types.ts
+++ b/src/utils/pwa-icons-types.ts
@@ -27,6 +27,7 @@ export async function registerPwaIconsTypes(
   nuxt.options.build.transpile.push('#pwa')
 
   addImports([
+    'usePWA',
     'useTransparentPwaIcon',
     'useMaskablePwaIcon',
     'useFaviconPwaIcon',


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->
Add `usePWA` composable to the imports added in #183

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
