### PR TITLE
chore: include sharp to pnpm built dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - playground/
   - playground-assets/
+onlyBuiltDependencies:
+  - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,6 @@ packages:
   - playground-assets/
 onlyBuiltDependencies:
   - sharp
+ignoredBuiltDependencies:
+  - esbuild
+  - vue-demi


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->
We need to run `pnpm approve-builds` to allow run `playground-assets`: once we run `pnpm approve-builds` and select `sharp`, the build folder with the corresponding binary is added when running the sharp install script. `pnpm` will add sharp to the workspace entry and sharp binaries will be installed when runnung the `pnpm` install script  (I need to test it with this branch, tested only on my local 🤞 )

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
![imagen](https://github.com/user-attachments/assets/77a27bf4-e3f0-4aa3-8966-a1106385d8bb)
_playground-assets error_
---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
