### PR TITLE
feat: add `service-worker` client runtime hooks

### DIFF
--- a/playground/plugins/pwa.client.ts
+++ b/playground/plugins/pwa.client.ts
@@ -1,0 +1,13 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.hook('service-worker:registered', ({ url, registration }) => {
+    // eslint-disable-next-line no-console
+    console.log(`service worker registered at ${url}`, registration)
+  })
+  nuxtApp.hook('service-worker:registration-failed', ({ error }) => {
+    console.error(`service worker registration failed`, error)
+  })
+  nuxtApp.hook('service-worker:activated', ({ url, registration }) => {
+    // eslint-disable-next-line no-console
+    console.log(`service worker activated at ${url}`, registration)
+  })
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 packages:
   - playground/
   - playground-assets/
-onlyBuiltDependencies:
-  - sharp
 ignoredBuiltDependencies:
   - esbuild
   - vue-demi
+onlyBuiltDependencies:
+  - sharp

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import type { HookResult } from '@nuxt/schema'
 import type { PwaModuleOptions } from './types'
 import { defineNuxtModule } from '@nuxt/kit'
 import { version } from '../package.json'
@@ -6,6 +7,32 @@ import { doSetup } from './utils/module'
 export * from './types'
 
 export interface ModuleOptions extends PwaModuleOptions {}
+
+export interface ModuleRuntimeHooks {
+  /**
+   * Emitted when the service worker is registered
+   * @param data The url and the optional service worker registration object
+   */
+  'service-worker:registered': (data: {
+    url: string
+    registration?: ServiceWorkerRegistration
+  }) => HookResult
+  /**
+   * Emitted when the service worker registration fails
+   * @param data The optional error object
+   */
+  'service-worker:registration-failed': (data: {
+    error?: unknown
+  }) => HookResult
+  /**
+   * Emitted when the service worker is activated
+   * @param data The url and the service worker registration object
+   */
+  'service-worker:activated': (data: {
+    url: string
+    registration: ServiceWorkerRegistration
+  }) => HookResult
+}
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {

--- a/src/runtime/plugins/pwa.client.ts
+++ b/src/runtime/plugins/pwa.client.ts
@@ -8,139 +8,152 @@ import { nextTick, reactive, ref } from 'vue'
 
 const plugin: Plugin<{
   pwa?: UnwrapNestedRefs<PwaInjection>
-}> = defineNuxtPlugin(() => {
-  const registrationError = ref(false)
-  const swActivated = ref(false)
-  const showInstallPrompt = ref(false)
-  const hideInstall = ref(!installPrompt ? true : localStorage.getItem(installPrompt) === 'true')
+}> = defineNuxtPlugin({
+  name: 'vite-pwa:nuxt:client:plugin',
+  enforce: 'post',
+  parallel: true,
+  setup(nuxtApp) {
+    const registrationError = ref(false)
+    const swActivated = ref(false)
+    const showInstallPrompt = ref(false)
+    const hideInstall = ref(!installPrompt ? true : localStorage.getItem(installPrompt) === 'true')
 
-  // https://thomashunter.name/posts/2021-12-11-detecting-if-pwa-twa-is-installed
-  const ua = navigator.userAgent
-  const ios = ua.match(/iPhone|iPad|iPod/)
-  const useDisplay = display === 'standalone' || display === 'minimal-ui' ? `${display}` : 'standalone'
-  const standalone = window.matchMedia(`(display-mode: ${useDisplay})`).matches
-  const isInstalled = ref(!!(standalone || (ios && !ua.match(/Safari/))))
-  const isPWAInstalled = ref(isInstalled.value)
+    // https://thomashunter.name/posts/2021-12-11-detecting-if-pwa-twa-is-installed
+    const ua = navigator.userAgent
+    const ios = ua.match(/iPhone|iPad|iPod/)
+    const useDisplay = display === 'standalone' || display === 'minimal-ui' ? `${display}` : 'standalone'
+    const standalone = window.matchMedia(`(display-mode: ${useDisplay})`).matches
+    const isInstalled = ref(!!(standalone || (ios && !ua.match(/Safari/))))
+    const isPWAInstalled = ref(isInstalled.value)
 
-  window.matchMedia(`(display-mode: ${useDisplay})`).addEventListener('change', (e) => {
-    // PWA on fullscreen mode will not match standalone nor minimal-ui
-    if (!isPWAInstalled.value && e.matches)
-      isPWAInstalled.value = true
-  })
+    window.matchMedia(`(display-mode: ${useDisplay})`).addEventListener('change', (e) => {
+      // PWA on fullscreen mode will not match standalone nor minimal-ui
+      if (!isPWAInstalled.value && e.matches)
+        isPWAInstalled.value = true
+    })
 
-  let swRegistration: ServiceWorkerRegistration | undefined
+    let swRegistration: ServiceWorkerRegistration | undefined
 
-  const getSWRegistration = () => swRegistration
+    const getSWRegistration = () => swRegistration
 
-  const registerPeriodicSync = (swUrl: string, r: ServiceWorkerRegistration, timeout: number) => {
-    setInterval(async () => {
-      if (('connection' in navigator) && !navigator.onLine)
-        return
+    const registerPeriodicSync = (swUrl: string, r: ServiceWorkerRegistration, timeout: number) => {
+      setInterval(async () => {
+        if (('connection' in navigator) && !navigator.onLine)
+          return
 
-      const resp = await fetch(swUrl, {
-        cache: 'no-store',
-        headers: {
-          'cache': 'no-store',
-          'cache-control': 'no-cache',
-        },
-      })
+        const resp = await fetch(swUrl, {
+          cache: 'no-store',
+          headers: {
+            'cache': 'no-store',
+            'cache-control': 'no-cache',
+          },
+        })
 
-      if (resp?.status === 200)
-        await r.update()
-    }, timeout)
-  }
+        if (resp?.status === 200)
+          await r.update()
+      }, timeout)
+    }
 
-  const {
-    offlineReady,
-    needRefresh,
-    updateServiceWorker,
-  } = useRegisterSW({
-    immediate: true,
-    onRegisterError() {
-      registrationError.value = true
-    },
-    onRegisteredSW(swUrl, r) {
-      swRegistration = r
-      const timeout = periodicSyncForUpdates
-      if (timeout > 0) {
+    const {
+      offlineReady,
+      needRefresh,
+      updateServiceWorker,
+    } = useRegisterSW({
+      immediate: true,
+      onRegisterError(error) {
+        nuxtApp.hooks.callHook('service-worker:registration-failed', { error: error as unknown })
+        registrationError.value = true
+      },
+      onRegisteredSW(swUrl, r) {
+        swRegistration = r
+        const timeout = periodicSyncForUpdates
+        nuxtApp.hooks.callHook('service-worker:registered', { url: swUrl, registration: r })
         // should add support in pwa plugin
         if (r?.active?.state === 'activated') {
           swActivated.value = true
-          registerPeriodicSync(swUrl, r, timeout * 1000)
+          nuxtApp.hooks.callHook('service-worker:activated', { url: swUrl, registration: r })
+          if (timeout > 0) {
+            registerPeriodicSync(swUrl, r, timeout * 1000)
+          }
         }
         else if (r?.installing) {
           r.installing.addEventListener('statechange', (e) => {
             const sw = e.target as ServiceWorker
             swActivated.value = sw.state === 'activated'
-            if (swActivated.value)
-              registerPeriodicSync(swUrl, r, timeout * 1000)
+            if (swActivated.value) {
+              nuxtApp.hooks.callHook('service-worker:activated', { url: swUrl, registration: r })
+              if (timeout > 0) {
+                registerPeriodicSync(swUrl, r, timeout * 1000)
+              }
+            }
           })
         }
-      }
-    },
-  })
-
-  const cancelPrompt = async () => {
-    offlineReady.value = false
-    needRefresh.value = false
-  }
-
-  let install: () => Promise<UserChoice | undefined> = () => Promise.resolve(undefined)
-  let cancelInstall: () => void = () => {}
-
-  if (!hideInstall.value) {
-    let deferredPrompt: BeforeInstallPromptEvent | undefined
-
-    const beforeInstallPrompt = (e: Event) => {
-      e.preventDefault()
-      deferredPrompt = e as BeforeInstallPromptEvent
-      showInstallPrompt.value = true
-    }
-    window.addEventListener('beforeinstallprompt', beforeInstallPrompt)
-    window.addEventListener('appinstalled', () => {
-      deferredPrompt = undefined
-      showInstallPrompt.value = false
+      },
     })
 
-    cancelInstall = () => {
-      deferredPrompt = undefined
-      showInstallPrompt.value = false
-      window.removeEventListener('beforeinstallprompt', beforeInstallPrompt)
-      hideInstall.value = true
-      localStorage.setItem(installPrompt!, 'true')
+    const cancelPrompt = async () => {
+      offlineReady.value = false
+      needRefresh.value = false
     }
 
-    install = async () => {
-      if (!showInstallPrompt.value || !deferredPrompt) {
+    let install: () => Promise<UserChoice | undefined> = () => Promise.resolve(undefined)
+    let cancelInstall: () => void = () => {
+    }
+
+    if (!hideInstall.value) {
+      let deferredPrompt: BeforeInstallPromptEvent | undefined
+
+      const beforeInstallPrompt = (e: Event) => {
+        e.preventDefault()
+        deferredPrompt = e as BeforeInstallPromptEvent
+        showInstallPrompt.value = true
+      }
+      window.addEventListener('beforeinstallprompt', beforeInstallPrompt)
+      window.addEventListener('appinstalled', () => {
+        deferredPrompt = undefined
         showInstallPrompt.value = false
-        return undefined
+      })
+
+      cancelInstall = () => {
+        deferredPrompt = undefined
+        showInstallPrompt.value = false
+        window.removeEventListener('beforeinstallprompt', beforeInstallPrompt)
+        hideInstall.value = true
+        localStorage.setItem(installPrompt!, 'true')
       }
 
-      showInstallPrompt.value = false
-      await nextTick()
-      deferredPrompt.prompt()
-      return await deferredPrompt.userChoice
-    }
-  }
+      install = async () => {
+        if (!showInstallPrompt.value || !deferredPrompt) {
+          showInstallPrompt.value = false
+          return undefined
+        }
 
-  return {
-    provide: {
-      pwa: reactive({
-        isInstalled,
-        isPWAInstalled,
-        showInstallPrompt,
-        cancelInstall,
-        install,
-        swActivated,
-        registrationError,
-        offlineReady,
-        needRefresh,
-        updateServiceWorker,
-        cancelPrompt,
-        getSWRegistration,
-      }) satisfies UnwrapNestedRefs<PwaInjection>,
-    },
-  }
+        showInstallPrompt.value = false
+        await nextTick()
+        deferredPrompt.prompt()
+        return await deferredPrompt.userChoice
+      }
+    }
+
+    return {
+      provide: {
+        pwa: reactive({
+          isInstalled,
+          isPWAInstalled,
+          showInstallPrompt,
+          cancelInstall,
+          install,
+          swActivated,
+          registrationError,
+          offlineReady,
+          needRefresh,
+          updateServiceWorker,
+          cancelPrompt,
+          getSWRegistration,
+        }) satisfies UnwrapNestedRefs<PwaInjection>,
+      },
+    }
+  },
 })
 
 export default plugin

--- a/src/runtime/plugins/types.d.ts
+++ b/src/runtime/plugins/types.d.ts
@@ -27,7 +27,7 @@ export interface PwaInjection {
   updateServiceWorker: (reloadPage?: boolean | undefined) => Promise<void>
   cancelPrompt: () => Promise<void>
   /**
-   * Use a plugin and the new Nuxt Runtime Client Hooks:
+   * From version 0.10.8 it is deprecated, use a plugin instead with the new Nuxt Runtime Client Hooks:
    * ```ts
    * // plugins/pwa.client.ts
    * export default defineNuxtPlugin((nuxtApp) => {
@@ -44,7 +44,8 @@ export interface PwaInjection {
    *   })
    * })
    * ```
-   * @depreacated
+   *
+   * @deprecated
    */
   getSWRegistration: () => ServiceWorkerRegistration | undefined
 }

--- a/src/runtime/plugins/types.d.ts
+++ b/src/runtime/plugins/types.d.ts
@@ -26,6 +26,26 @@ export interface PwaInjection {
   needRefresh: Ref<boolean>
   updateServiceWorker: (reloadPage?: boolean | undefined) => Promise<void>
   cancelPrompt: () => Promise<void>
+  /**
+   * Use a plugin and the new Nuxt Runtime Client Hooks:
+   * ```ts
+   * // plugins/pwa.client.ts
+   * export default defineNuxtPlugin((nuxtApp) => {
+   *   nuxtApp.hook('service-worker:registered', ({ url, registration }) => {
+   *     // eslint-disable-next-line no-console
+   *     console.log(`service worker registered at ${url}`, registration)
+   *   })
+   *   nuxtApp.hook('service-worker:registration-failed', ({ error }) => {
+   *     console.error(`service worker registration failed`, error)
+   *   })
+   *   nuxtApp.hook('service-worker:activated', ({ url, registration }) => {
+   *     // eslint-disable-next-line no-console
+   *     console.log(`service worker activated at ${url}`, registration)
+   *   })
+   * })
+   * ```
+   * @depreacated
+   */
   getSWRegistration: () => ServiceWorkerRegistration | undefined
 }
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->
This PR deprecates `getSWRegistration` from `PwaInjection` adding 3 Nuxt Client Runtime Hooks to allow access the service worker registration when it is ready (via `service-worker:activated` hook).

This PR also prevents fetching the service worker (check for update) when a new service worker being installed.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
