### PR TITLE
feat(generateSW): add experimental payload json file runtime caching

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,16 +27,17 @@ export interface PwaModuleOptions extends Partial<VitePWAOptions> {
    */
   experimental?: {
     /**
-     * NOTE: this option will be ignored if using `injectManifest` strategy or when Nuxt experimental payload extraction
-     * is disabled.
+     * NOTE: this option will be ignored if using the `injectManifest` strategy or when Nuxt experimental payload
+     * extraction is disabled.
      *
-     * Enable custom runtime caching to resolve the payload.json requests with query parameters:
+     * Enable custom runtime caching to resolve the payload.json requests with query parameters when offline:
      * - Workbox doesn't allow to configure `precacheAndRoute` `urlManipulation` option when using the `generateSW` strategy.
      * - Nuxt SSG will generate a payload.json file and will fetch it with a query parameter.
-     * - The service worker cannot resolve the payload.json request with query parameters, and you won't get the payload.
+     * - The service worker cannot resolve the payload.json request with query parameters, and you won't get the payload when offline.
      *
      * Enabling this option will add a custom runtime caching handler to the service worker to resolve the payload files
-     * with query parameters.
+     * with query parameters when offline: the runtime caching handler will redirect to the payload.json file without
+     * query parameters when the original request fails.
      *
      * If you're using `injectManifest` strategy, you can fix the issue in your custom service worker adding the
      * following `urlManipulation` callback to the `precacheAndRouter` call:

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,43 @@ export interface ClientOptions {
 }
 
 export interface PwaModuleOptions extends Partial<VitePWAOptions> {
+  /**
+   * Experimental features.
+   */
+  experimental?: {
+    /**
+     * NOTE: this option will be ignored if using `injectManifest` strategy or when Nuxt experimental payload extraction
+     * is disabled.
+     *
+     * Enable custom runtime caching to resolve the payload.json requests with query parameters:
+     * - Workbox doesn't allow to configure `precacheAndRoute` `urlManipulation` option when using the `generateSW` strategy.
+     * - Nuxt SSG will generate a payload.json file and will fetch it with a query parameter.
+     * - The service worker cannot resolve the payload.json request with query parameters, and you won't get the payload.
+     *
+     * Enabling this option will add a custom runtime caching handler to the service worker to resolve the payload files
+     * with query parameters.
+     *
+     * If you're using `injectManifest` strategy, you can fix the issue in your custom service worker adding the
+     * following `urlManipulation` callback to the `precacheAndRouter` call:
+     * ```ts
+     * // self.__WB_MANIFEST is the default injection point
+     * precacheAndRoute(
+     *   self.__WB_MANIFEST,
+     *   {
+     *     urlManipulation: ({ url }) => {
+     *       const urls: URL[] = []
+     *       if (url.pathname.endsWith('_payload.json')) {
+     *         const newUrl = new URL(url.href)
+     *         newUrl.search = ''
+     *         urls.push(newUrl)
+     *      }
+     *      return urls
+     *    }
+     *  }
+     * )
+     */
+    enableWorkboxPayloadQueryParams?: true
+  }
   registerWebManifestInRouteRules?: boolean
   /**
    * Writes the plugin to disk: defaults to false (debug).


### PR DESCRIPTION
### Description

Add new experimental workbox (`generateSW` strategy) option to add a custom runtime caching to resolve the `payload.json` requests with query parameters:
- Workbox doesn't allow to configure `precacheAndRoute` `urlManipulation` option when using the `generateSW` strategy.
- Nuxt SSG will generate a payload.json file and will fetch it with a query parameter.
- The service worker cannot resolve the payload.json request with query parameters, and you won't get the payload when offline.

Enabling this option will add a custom runtime caching handler to the service worker to resolve the payload files
with query parameters when you're offline.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
