### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -63,7 +63,7 @@ export function configurePWAOptions(
 
   // handle payload extraction
   if (nuxt.options.experimental.payloadExtraction) {
-    const enableGlobPatterns = nuxt.options._generate
+    const enableGlobPatterns = nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */
       || (
         !!nitroConfig.prerender?.routes?.length
         || Object.values(nitroConfig.routeRules ?? {}).some(r => r.prerender)

--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -325,7 +325,7 @@ export const periodicSyncForUpdates = ${typeof client.periodicSyncForUpdates ===
           )
         })
       })
-      if (nuxt.options._generate) {
+      if (nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) {
         nuxt.hook('close', async () => {
           await regeneratePWA(
             options.outDir!,


### PR DESCRIPTION
### Description

Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest we remove support in a future major.