### PR TITLE
fix(dev): ensure navigateFallbackAllowlist matches exact path

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -102,8 +102,13 @@ export function configurePWAOptions(
   }
 
   // allow override manifestTransforms
-  if (!nuxt.options.dev && !config.manifestTransforms)
-    config.manifestTransforms = [createManifestTransform(nuxt.options.app.baseURL ?? '/', options.outDir, appManifestFolder)]
+  if (options.devOptions?.enabled && !options.devOptions.navigateFallbackAllowlist) {
+    const baseURL = nuxt.options.app.baseURL
+    // fix #214
+    options.devOptions.navigateFallbackAllowlist = [baseURL
+      ? new RegExp(`^${baseURL.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`)
+      : /^\/$/]
+  }
 
   if (options.pwaAssets) {
     options.pwaAssets.integration = {


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR just changes the `devOptions.navigateFallbackAllowlist` logic here, right now intercepting everything.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->
closes #214

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
