### PR TITLE
fix(dev): ensure navigateFallbackAllowlist matches exact path (2)

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -42,13 +42,11 @@ export function configurePWAOptions(
       // on dev force always to use the root
       options.workbox.navigateFallback = options.workbox.navigateFallback ?? nuxt.options.app.baseURL ?? '/'
       if (options.devOptions?.enabled && !options.devOptions.navigateFallbackAllowlist) {
-        if (options.devOptions?.enabled && !options.devOptions.navigateFallbackAllowlist) {
-          const baseURL = nuxt.options.app.baseURL
-          // fix #214
-          options.devOptions.navigateFallbackAllowlist = [baseURL
-            ? new RegExp(`^${baseURL.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`)
-            : /^\/$/]
-        }
+        const baseURL = nuxt.options.app.baseURL
+        // fix #214
+        options.devOptions.navigateFallbackAllowlist = [baseURL
+          ? new RegExp(`^${baseURL.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}$`)
+          : /^\/$/]
       }
     }
     // the user may want to disable offline support


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
This PR reverts changes included at #216 , wrong place to add the fix, #216 removing workbox `manifestTransforms`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/nuxt/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/nuxt!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
