### PR TITLE
chore: change name to `@vite-pwa/nuxt` in module meta

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -38,7 +38,7 @@ export interface ModuleRuntimeHooks {
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
-    name: 'pwa',
+    name: '@vite-pwa/nuxt',
     configKey: 'pwa',
     compatibility: {
       nuxt: '>=3.6.5',


### PR DESCRIPTION
### Description

The module name must be the same as the npm package name, otherwise we cannot include it in `moduleDependencies` (read [docs](https://nuxt.com/docs/4.x/api/kit/modules#specifying-module-dependencies))

With the current name it hints `pwa`  field

<img width="559" height="181" alt="image" src="https://github.com/user-attachments/assets/916b0d92-3543-4d9e-9ed2-e96153a22bb2" />

\
Which leads to an error if we try to add `pwa` to `moduleDependencies`
```bash
Could not load pwa. Is it installed?
```
\
Renaming module to `@vite-pwa/nuxt` solves the problem.

<img width="511" height="138" alt="image" src="https://github.com/user-attachments/assets/97985393-70c3-424d-bd86-3257247f0bf4" />



---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
